### PR TITLE
Fix access _output_size_init via self in FCRN.py

### DIFF
--- a/models/FCRN.py
+++ b/models/FCRN.py
@@ -235,7 +235,7 @@ class fusion_ResNet(nn.Module):
 
         self.output_size = output_size
         if output_size == None:
-            output_size = _output_size_init
+            output_size = self._output_size_init
         else:
             assert isinstance(output_size, tuple)
         self.relu = pretrained_model._modules['relu']


### PR DESCRIPTION
Hello

In models/FCRN.py:
```
class fusion_ResNet(nn.Module):
    _output_size_init = (256, 256)

    def __init__(self, bs, layers, decoder, output_size=None, in_channels=3, pretrained=True, padding='ZeroPad'):

        ...
        if output_size == None:
            output_size = _output_size_init  # undefined variable, changed to self._output_size_init
```
